### PR TITLE
Let KeyboardInterrupt (Ctrl-C) end the break early

### DIFF
--- a/concentration/run.py
+++ b/concentration/run.py
@@ -67,16 +67,19 @@ def take_break(minutes: hug.types.number=5):
     lose()
     print("")
     print("######################################### TAKING A BREAK ####################################")
-    for remaining in range(minutes * 60, -1, -1):
-        sys.stdout.write("\r")
-        sys.stdout.write("{:2d} seconds remaining without concentration.".format(remaining))
-        sys.stdout.flush()
-        time.sleep(1)
-
-    sys.stdout.write("\rEnough distraction!                                                            ")
-    print("######################################### BREAK OVER :) ####################################")
-    print("")
-    improve()
+    try:
+        for remaining in range(minutes * 60, -1, -1):
+            sys.stdout.write("\r")
+            sys.stdout.write("{:2d} seconds remaining without concentration.".format(remaining))
+            sys.stdout.flush()
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        sys.stdout.write("\rEnough distraction!                                                            ")
+        print("######################################### BREAK OVER :) ####################################")
+        print("")
+        improve()
 
 
 @hug.cli()


### PR DESCRIPTION
Hi Timothy,
Sometimes I want to end a break early. In its current incarnation, Ctrl-C during a concentration break will present the user with a traceback and leave the /etc/hosts file in its 'distracted' state. This pull request wraps the timer loop in a `try...except KeyboardException` block  with a `finally` clause that ensures the break is ended cleanly normally, but also when it is interrupted.
