### PR TITLE
Let KeyboardInterrupt (Ctrl-C) end the break early

### DIFF
--- a/ACKNOWLEDGE.md
+++ b/ACKNOWLEDGE.md
@@ -9,6 +9,7 @@ Notable Bug Reporters
 Code Contributors
 ===================
 - Richard Killam (@rkillam)
+- Sietse Brouwer (https://bitbucket.org/sietsebb)
 
 Documenters
 ===================

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Concentration
 
 Stay focused on work when you want, and goof off when you don't. Concentration is a simple
 Python 3 console utility to block distracting sites when you need to focus, while allowing you to easily
-take timed breaks. Internally uses /etc/hosts file as the mechanism to block sites.
+take timed breaks. Concentration uses the /etc/hosts file as the mechanism to
+block sites, and works on Linux, Macintosh, and Windows.
 
 ![Concentration Example](https://raw.github.com/timothycrosley/concentration/develop/example.gif)
 
@@ -33,7 +34,9 @@ To take a long 60 minute timed break:
 
     sudo concentration break -m 60
 
-To access all sites:
+You can cancel breaks with `Ctrl-C`.
+
+To disable blocking until you explicitly enable it again:
 
     sudo concentration lose
 

--- a/concentration/run.py
+++ b/concentration/run.py
@@ -64,6 +64,21 @@ def lose():
 @hug.cli('break')
 def take_break(minutes: hug.types.number=5):
     """Enables temporarily breaking concentration"""
+    print("")
+    print("######################################### ARE YOU SURE? #####################################")
+    try:
+        for remaining in range(60, -1, -1):
+            sys.stdout.write("\r")
+            sys.stdout.write("{:2d} seconds to change your mind. Won't you prefer programming? Or a book?".format(remaining))
+            sys.stdout.flush()
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("")
+        print("")
+        print(":D :D :D\nGood on you! <3")
+        return
+
+    # The user insisted on breaking concentration.
     lose()
     print("")
     print("######################################### TAKING A BREAK ####################################")

--- a/concentration/run.py
+++ b/concentration/run.py
@@ -67,16 +67,19 @@ def take_break(minutes: hug.types.number=5):
     lose()
     print("")
     print("######################################### TAKING A BREAK ####################################")
-    for remaining in range(minutes * 60, -1, -1):
-        sys.stdout.write("\r")
-        sys.stdout.write("{:2d} seconds remaining without concentration.".format(remaining))
-        sys.stdout.flush()
-        time.sleep(1)
-
-    sys.stdout.write("\rEnough distraction!                                                            ")
-    print("######################################### BREAK OVER :) ####################################")
-    print("")
-    improve()
+    try:
+        for remaining in range(minutes * 60, -1, -1):
+            sys.stdout.write("\r")
+            sys.stdout.write("{:2d} seconds remaining without concentration.".format(remaining))
+            sys.stdout.flush()
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        sys.stdout.write("\rEnough distraction!                                                            \n")
+        print("######################################### BREAK OVER :) #####################################")
+        print("")
+        improve()
 
 
 @hug.cli()


### PR DESCRIPTION
Hi Timothy,

Here is a more complete patch that
- ensures that concentration is always re-improved when a break ends, whether it ended naturally or because of a `KeyboardInterrupt`.
- updates the `README.md` to mention that `Ctrl-C` is supported
- updates the `README.md` to mention that Concentration works on Linux, Macintosh, and Windows.
- updates the `ACKNOWLEDGE.md`.

Thank you very much for creating Concentration, it is one of the first things I install when provisioning a new OS. The timed breaks are fantastic, and I really like the conversational style of commands like 'concentration improve' and 'concentration lose'.

Cheers,
Sietse
