### PR TITLE
Adaptive banner width

### DIFF
--- a/concentration/output.py
+++ b/concentration/output.py
@@ -1,0 +1,10 @@
+"""concentration/settings.py
+
+Helpers for formatting CLI output.
+"""
+import shutil
+
+
+def banner(txt):
+    width, _ = shutil.get_terminal_size()
+    return txt.center(width, '#')

--- a/concentration/run.py
+++ b/concentration/run.py
@@ -9,7 +9,7 @@ import sys
 import time
 import hug
 
-from . import settings
+from . import output, settings
 
 
 def reset_network(message):
@@ -66,7 +66,7 @@ def take_break(minutes: hug.types.number=5):
     """Enables temporarily breaking concentration"""
     lose()
     print("")
-    print("######################################### TAKING A BREAK ####################################")
+    print(output.banner(" TAKING A BREAK "))
     for remaining in range(minutes * 60, -1, -1):
         sys.stdout.write("\r")
         sys.stdout.write("{:2d} seconds remaining without concentration.".format(remaining))
@@ -74,7 +74,8 @@ def take_break(minutes: hug.types.number=5):
         time.sleep(1)
 
     sys.stdout.write("\rEnough distraction!                                                            ")
-    print("######################################### BREAK OVER :) ####################################")
+    print("")
+    print(output.banner(" BREAK OVER :) "))
     print("")
     improve()
 

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,9 +1,9 @@
 -r common.txt
-pytest==2.6.1
-pytest-cov==1.8.1
-tox==1.7.2
-isort==4.2.2
-Cython==0.22.1
-ipython==3.2.1
-wheel==0.24.0
-python-coveralls==2.5.0
+pytest>=3.0.0
+pytest-cov>=2.0.0
+tox
+isort
+Cython
+ipython
+wheel
+python-coveralls

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,12 @@
+from unittest import mock
+from concentration import output
+
+
+def test_banner():
+    some_height = 24
+    with mock.patch('shutil.get_terminal_size', return_value=(12, some_height)):
+        assert output.banner('ABCD') == '####ABCD####'
+    with mock.patch('shutil.get_terminal_size', return_value=(24, some_height)):
+        assert output.banner('ABCD') == '##########ABCD##########'
+    with mock.patch('shutil.get_terminal_size', return_value=(2, some_height)):
+        assert output.banner('ABCD') == 'ABCD'

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -23,6 +23,6 @@ from concentration import run, settings
 
 
 def test_settings():
-    assert settings.PLATFORM in (settings.LINUX, settings.MAC, settings.WINDOWS)
+    assert settings.PLATFORM in (settings.OS.linux, settings.OS.mac, settings.OS.windows)
     assert settings.HOSTS_FILE and isinstance(settings.HOSTS_FILE, str)
-    assert settings.DISTRACTORS and isinstance(settings.DISTRACTORS, (list, tuple))
+    assert settings.DISTRACTORS and isinstance(settings.DISTRACTORS, (list, tuple, set))

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,5 @@ envlist=py34
 
 [testenv]
 deps=-rrequirements/development.txt
-commands=py.test --cov hug tests
+commands=py.test --cov concentration tests
     coverage report


### PR DESCRIPTION
I like `concentration`, but I don't like when banners in `concentration break` prints in a not nice way due to being longer that terminal window width.

This change introduces banners which width adapts to console width instead of being hardcoded.
